### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ "main" ]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/GoPolymarket/go-builder-relayer-client/security/code-scanning/1](https://github.com/GoPolymarket/go-builder-relayer-client/security/code-scanning/1)

In general, the fix is to define an explicit `permissions` block that grants only the scopes required by the job, either at the workflow root (applies to all jobs) or inside each job definition. For this workflow, the steps only check out code and run `go build` / `go test`, so they only need read access to repository contents. The single best fix is to add `permissions: contents: read` at the workflow level, right after the `on:` block and before `jobs:`, so all jobs inherit it without changing any other behavior.

Concretely, in `.github/workflows/go.yml`, between the existing `on:` section (lines 3–7) and the `jobs:` section (line 9), insert:

```yaml
permissions:
  contents: read
```

No other imports or definitions are required. This documents that the workflow requires only read access to repository contents and constrains the `GITHUB_TOKEN` accordingly, without modifying any functional aspects of the build and test steps.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
